### PR TITLE
Change the algorithm of the wb_amr

### DIFF
--- a/audio/ril_interface.c
+++ b/audio/ril_interface.c
@@ -60,7 +60,7 @@ static int ril_set_wb_amr_callback(void *ril_client,
 {
     int enable = ((int *)data)[0];
 
-    if (!callback_data || !_audio_set_wb_amr_callback)
+    if (!callback_data || _audio_set_wb_amr_callback)
         return -1;
 
     _audio_set_wb_amr_callback(callback_data, enable);


### PR DESCRIPTION
If this will always check if it's not exist, then it will never get set!
If the wb is already set, we can return -1. If it's not set, we need to set it up!!
So set it up, and finish.
