### PR TITLE
Power profile: Add missing values + fix order

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -29,6 +29,8 @@
         <value>1000000</value>
         <value>900000</value>
         <value>800000</value>
+        <value>700000</value>
+        <value>650000</value>
         <value>600000</value>
         <value>550000</value>
         <value>500000</value>
@@ -41,11 +43,11 @@
     <item name="cpu.idle">2.5</item>
     <item name="cpu.awake">62.3</item>
     <array name="cpu.active">
-        <value>1175</value>
-        <value>1545</value>
         <value>1860</value>
         <value>1619</value>
+        <value>1545</value>
         <value>1293</value>
+        <value>1175</value>
         <value>1043</value>
         <value>841</value>
         <value>704</value>


### PR DESCRIPTION
Our device can be clocked on 650Mhz and 700Mhz,
and also order the "cpu.active" values
