### PR TITLE
Enable Call recording for the device

### DIFF
--- a/overlay/packages/apps/Dialer/res/values/config.xml
+++ b/overlay/packages/apps/Dialer/res/values/config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2014 The CyanogenMod Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <bool name="call_recording_enabled">true</bool>
+</resources>


### PR DESCRIPTION
This commit allow the initial support for the call recording feature of cyanogenmod.
It will be disabled for the restricted areas according to the CM policy.
