### PR TITLE
i9500: audio: mixer_paths.xml: reduce back mic volume while in-call

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -1046,8 +1046,8 @@
     </path>
 
     <path name="volume-back-mic-incall">
-      <ctl name="IN2L Volume" value="17" />
-      <ctl name="IN2L Digital Volume" value="128" />
+      <ctl name="IN2L Volume" value="15" />
+      <ctl name="IN2L Digital Volume" value="112" />
       <ctl name="LHPF2 Input 1 Volume" value="32" />
     </path>
 


### PR DESCRIPTION
A try to fix the echo problem, which caused by the mic getting the
sound from the earpiece speaker, as they are close to each other phisically.
