### PR TITLE
i9500: audio: mixer_paths.xml: Fix the echo problem

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -986,8 +986,8 @@
     </path>
 
     <path name="volume-builtin-mic-incall">
-      <ctl name="IN1L Volume" value="31" />
-      <ctl name="IN1L Digital Volume" value="150" />
+      <ctl name="IN1L Volume" value="24" />
+      <ctl name="IN1L Digital Volume" value="112" />
       <ctl name="LHPF1 Input 1 Volume" value="32" />
     </path>
 


### PR DESCRIPTION
The echo problem was caused by the main mic being "too" strong, and causing in to catch
the earpiece sound, which made the other side to hear themselves more than once.
Reducing it to this level corrects the "overhear", but not harming the sound call quality,
as the main mic is much stronger than we thought.
