### PR TITLE
i9500: audio: mixer_paths.xml: Reducing speaker volume

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -681,7 +681,7 @@
     <!-- ### Volume ### -->
 
     <path name="volume-speaker-default">
-      <ctl name="Speaker Digital Volume" value="126" />
+      <ctl name="Speaker Digital Volume" value="120" />
       <ctl name="SPKOUTL Input 1 Volume" value="32" />
       <ctl name="SPKOUTL Input 2 Volume" value="32" />
     </path>


### PR DESCRIPTION
Keeping the volume at this level does nothing but causing distortion, which isn't healty
to the speaker at all. Reduce it a bit, to soft the distortion with the minimal loss of max volume.
