### PR TITLE
i9500: Add relevant codecs back

### DIFF
--- a/i9500.mk
+++ b/i9500.mk
@@ -152,6 +152,14 @@ PRODUCT_COPY_FILES += \
 
 # OMX
 PRODUCT_PACKAGES += \
+	libExynosOMX_Core \
+	libOMX.Exynos.MPEG4.Decoder \
+	libOMX.Exynos.AVC.Decoder \
+	libOMX.Exynos.H263.Decoder \
+	libOMX.Exynos.VP8.Decoder \
+	libOMX.Exynos.MPEG4.Encoder \
+	libOMX.Exynos.AVC.Encoder \
+	libOMX.Exynos.H263.Encoder \
 	libstagefrighthw
 
 # Extra Apps


### PR DESCRIPTION
Probably mistakley deleted, this removal completely broke video playback in the build.
So re-add and update to the current relevant codecs (Without MPEG2)
