### PR TITLE
i9500: Remove density from PRODUCT_AAPT_CONFIG

### DIFF
--- a/i9500.mk
+++ b/i9500.mk
@@ -283,7 +283,7 @@ PRODUCT_PACKAGES += \
 	power.universal5410
 
 # Device uses high-density artwork where available
-PRODUCT_AAPT_CONFIG := normal hdpi xhdpi xxhdpi
+PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 	
 # call dalvik heap config


### PR DESCRIPTION
AAPT ignores densities in PRODUCT_AAPT_CONFIG.
The use of PRODUCT_AAPT_PREF_CONFIG for density is
encouraged, as AAPT is able to determine the fallback
density to use if a resource of the specified density
does not exist.

http://review.cyanogenmod.org/#/c/95887/
